### PR TITLE
Include docs in the backend app

### DIFF
--- a/backend/CHANGELOG.md
+++ b/backend/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- [BE-01](https://github.com/lysnikolaou/eatandmeet/issues/3) User Model and API in Database
+- [BE-02](https://github.com/lysnikolaou/eatandmeet/issues/36) User Authentication
+- [BE-03](https://github.com/lysnikolaou/eatandmeet/issues/6) Page Admins
+- [BE-04](https://github.com/lysnikolaou/eatandmeet/issues/9) Event Model and API in Database

--- a/backend/eatandmeet/eatandmeet/urls.py
+++ b/backend/eatandmeet/eatandmeet/urls.py
@@ -1,10 +1,10 @@
 from django.contrib import admin
 from django.urls import path, include
-
-
+from rest_framework.documentation import include_docs_urls
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('docs/', include_docs_urls(title='Eat and Meet Docs')),
     path('api/',include('api.urls')),
     path('', include('authentication.urls'))
 ]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,9 +1,11 @@
 atomicwrites==1.3.0
 attrs==19.1.0
-Django==2.2.1
+coreapi==2.3.3
+Django==2.2.2
 django-multiselectfield==0.1.8
 django-rest-knox==4.0.1
 djangorestframework==3.9.4
+Markdown==3.1.1
 more-itertools==7.0.0
 pluggy==0.11.0
 py==1.8.0


### PR DESCRIPTION
Include a docs page, where the docs of the backend app can be viewed by the frontend developers.

### Change
- URLs to include docs

### Changelog
- [X] changelog updated with your changes


### Issuer
- #52
